### PR TITLE
Bump version dependencies for stdlib and archive

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,11 +10,11 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 <6.0.0"
+      "version_requirement": ">= 4.13.1 <7.0.0"
     },
     {
       "name": "puppet/archive",
-      "version_requirement": ">= 1.0.0 <4.0.0"
+      "version_requirement": ">= 1.0.0 <5.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Stdlib and archive dependencies could be raised to be able to use newest versions.